### PR TITLE
Consolidation of language type collisions, plus clippy and fmt

### DIFF
--- a/linguist/src/container.rs
+++ b/linguist/src/container.rs
@@ -39,7 +39,6 @@ impl InMemoryLanguageContainer {
             if let Some(heuristic) = self.heuristics.get_mut(ext) {
                 if !heuristic.contains(&rule) {
                     heuristic.push(rule.clone());
-                } else {
                 }
             } else {
                 self.heuristics

--- a/linguist/src/resolver.rs
+++ b/linguist/src/resolver.rs
@@ -128,7 +128,7 @@ pub fn resolve_language_by_content(
             let matcher = Regex::new(&rule.patterns.join("|"))?;
 
             for line in content.lines() {
-                if matcher.is_match(&line) {
+                if matcher.is_match(line) {
                     return Ok(container.get_language_by_name(&rule.language));
                 }
             }
@@ -194,7 +194,6 @@ pub fn resolve_languages_by_shebang(
             .to_owned();
     }
 
-    let mut interpreter = interpreter;
     if interpreter == "sh" {
         interpreter = determine_multiline_exec(buf.buffer()).unwrap();
     }
@@ -241,7 +240,7 @@ pub fn resolve_language(
         for lang in candidate {
             *probabilities
                 .entry(lang.name.clone().to_lowercase())
-                .or_insert(1) += 1;
+                .or_insert(1) += 30;
         }
     }
 
@@ -249,14 +248,14 @@ pub fn resolve_language(
         for candidate in candidates {
             *probabilities
                 .entry(candidate.name.clone().to_lowercase())
-                .or_insert(1) += 1;
+                .or_insert(1) += 10;
         }
     }
 
     if let Ok(Some(candidate)) = resolve_language_by_content(&file, container) {
         *probabilities
             .entry(candidate.name.clone().to_lowercase())
-            .or_insert(1) += 1;
+            .or_insert(1) += 50;
     }
 
     let mut ordered: Vec<(&String, &usize)> = probabilities.iter().collect();

--- a/linguist/src/utils.rs
+++ b/linguist/src/utils.rs
@@ -106,7 +106,7 @@ pub(crate) fn determine_multiline_exec(data: &[u8]) -> Option<String> {
     let mut cursor = Cursor::new(data);
     let mut buf = String::new();
 
-    let shebang_exec = Regex::new(r#"exec (\w+).+\$0.+\$@"#).unwrap();
+    let shebang_exec = Regex::new(r"exec (\w+).+\$0.+\$@").unwrap();
 
     for _i in 0..5 {
         buf.clear();


### PR DESCRIPTION
Still getting some collisions with language types, in particular C# vs SmallTalk where small C# files are matched as SmallTalk.

Add a more robust probability regime, but this only reduces the collisions, not removed them.

Also ran clippy and fmt to align with the new GH workflow.